### PR TITLE
Fix wrong class name

### DIFF
--- a/ImageFunctions/Thumbnail.cs
+++ b/ImageFunctions/Thumbnail.cs
@@ -28,7 +28,7 @@ using System.Threading.Tasks;
 
 namespace ImageFunctions
 {
-    public static class Thunbnail
+    public static class Thumbnail
     {
         private static readonly string BLOB_STORAGE_CONNECTION_STRING = Environment.GetEnvironmentVariable("AzureWebJobsStorage");
 


### PR DESCRIPTION
Fix wrong class name: `Thunbnail` to `Thumbnail`