### PR TITLE
Fix encoding when filename extension is upper case

### DIFF
--- a/ImageFunctions/Thumbnail.cs
+++ b/ImageFunctions/Thumbnail.cs
@@ -43,7 +43,7 @@ namespace ImageFunctions
         {
             IImageEncoder encoder = null;
 
-            extension = extension.Replace(".", "");
+            extension = extension.Replace(".", "").ToLowerInvariant();
 
             var isSupported = Regex.IsMatch(extension, "gif|png|jpe?g", RegexOptions.IgnoreCase);
 


### PR DESCRIPTION
This sample is not working if the file save on the blob has its extension in uppercase, due to comparison case dependant.