### PR TITLE
Convert to lower case in switch function to cover edge cases.

### DIFF
--- a/ImageFunctions/Thumbnail.cs
+++ b/ImageFunctions/Thumbnail.cs
@@ -48,7 +48,7 @@ namespace ImageFunctions
 
             if (isSupported)
             {
-                switch (extension)
+                switch (extension.ToLower())
                 {
                     case "png":
                         encoder = new PngEncoder();


### PR DESCRIPTION
If the image extension is in caps, the code will exit without resizing the image.