### PR TITLE
Fix rounding error which causes aspect ratio to not be retained

### DIFF
--- a/ImageFunctions/Thumbnail.cs
+++ b/ImageFunctions/Thumbnail.cs
@@ -95,7 +95,7 @@ namespace ImageFunctions
                         using (var output = new MemoryStream())
                         using (Image<Rgba32> image = Image.Load(input))
                         {
-                            var divisor = image.Width / thumbnailWidth;
+                            var divisor = (decimal)image.Width / thumbnailWidth;
                             var height = Convert.ToInt32(Math.Round((decimal)(image.Height / divisor)));
 
                             image.Mutate(x => x.Resize(thumbnailWidth, height));


### PR DESCRIPTION
To reproduce the error, try uploading an image that's 1024x1024 pixels, then resize to 900px width. The width will be 900px but the height will be calculated as 1024px, because the divisor will be 1 due to integer truncation.

```
var divisor = 1024 / 900; // 1
```

The fix is:

```
var divisor = (decimal)image.Width / thumbnailWidth;
```



